### PR TITLE
Start data file paths from the current working directory

### DIFF
--- a/extended_tests/Q_bench.jl
+++ b/extended_tests/Q_bench.jl
@@ -36,7 +36,7 @@ function parse(::Type{Complex{T}}, s::AbstractString) where {T<:Real}
 end
 
 # input data from Mathematica and reparse into complex numbers
-data1 = CSV.read("../data/Q_test_data_1.csv"; delim=",", type=String)
+data1 = CSV.read(joinpath(@__DIR__, "..", "data", "Q_test_data_1.csv"); delim=",", type=String)
 #    has trouble reading in numbers like "2." so read all into strings, and parse
 data1[!,:n] = Int.(parse.(Float64, data1[!,:n] ))
 data1[!,:s] = parse.(Complex{Float64}, data1[!,:s] )

--- a/extended_tests/bernoulli_bench.jl
+++ b/extended_tests/bernoulli_bench.jl
@@ -5,12 +5,12 @@ using Polylogarithms
 using BenchmarkTools
 using DataFrames, CSV
 using PyPlot
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 
 ##############################################
 # Bernoulli numbers
 B = Symbol("B_n")
-data1 = CSV.read("../data/bernoulli_test_data_1.csv", DataFrame)
+data1 = CSV.read(joinpath(@__DIR__, "..", "data", "bernoulli_test_data_1.csv"), DataFrame)
 m = size(data1,1)
 B1 = zeros(Rational{Int64}, m)
 B1_ref = zeros(Rational{Int64}, m)
@@ -48,7 +48,7 @@ savefig("plots/bernoulli_bench_0.pdf")
 ##############################################
 # Bernoulli polynomials: data v x
 B = Symbol("B_n(x)")
-data2 = CSV.read("../data/bernoulli_test_data_2.csv", DataFrame; delim=",", type=String)
+data2 = CSV.read(joinpath(@__DIR__, "..", "data", "bernoulli_test_data_2.csv"), DataFrame; delim=",", type=String)
 data2[!,:n] = parse.(Float64, data2[!,:n] )
 data2[!,:x] = parse.(Float64, data2[!,:x] )
 data2[!,B] = parse.(Float64, data2[!,B] )
@@ -76,7 +76,7 @@ savefig("plots/bernoulli_bench_2.pdf")
 ##############################################u
 # Bernoulli polynomials: data v n
 B = Symbol("B_n(x)")
-data3 = CSV.read("../data/bernoulli_test_data_3.csv", DataFrame)
+data3 = CSV.read(joinpath(@__DIR__, "..", "data", "bernoulli_test_data_3.csv"), DataFrame)
 m = size(data3,1)
 B3 = zeros(Float64, m)
 B3_ref = zeros(Float64, m)

--- a/extended_tests/branch_test.jl
+++ b/extended_tests/branch_test.jl
@@ -3,7 +3,7 @@ using BenchmarkTools
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 
 series_1 = Polylogarithms.polylog_series_1
 series_2 = Polylogarithms.polylog_series_2

--- a/extended_tests/harmonic_bench.jl
+++ b/extended_tests/harmonic_bench.jl
@@ -10,7 +10,7 @@ H = Symbol("real(H_n)")
 
 ##############################################
 # integer arguments
-data1 = CSV.read("../data/harmonic_test_data_1.csv", DataFrame)
+data1 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_1.csv"), DataFrame)
 m = size(data1,1)
 H1 = zeros(Float64, m)
 error1 = zeros(Float64, m)
@@ -31,7 +31,7 @@ savefig("plots/harmonic_bench_1.pdf")
 
 ##############################################
 # real arguments
-data2 = CSV.read("../data/harmonic_test_data_2.csv", DataFrame)
+data2 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_2.csv"), DataFrame)
 m = size(data2,1)
 H2 = zeros(Float64, m)
 error2 = zeros(Float64, m)
@@ -58,7 +58,7 @@ zr = Symbol("Re(z)")
 zi = Symbol("Im(z)")
 Hr = Symbol("Re(H(z))")
 Hi = Symbol("Im(H(z))")
-data3 = CSV.read("../data/harmonic_test_data_3.csv", DataFrame)
+data3 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_3.csv"), DataFrame)
 m = size(data3,1)
 H3 = zeros(Complex{Float64}, m)
 error3 = zeros(Complex{Float64}, m)
@@ -86,7 +86,7 @@ savefig("plots/harmonic_bench_3.pdf")
 ##############################################
 # integer arguments for generalize H
 H = Symbol("real(H_{n,r})")
-data4 = CSV.read("../data/harmonic_test_data_4.csv", DataFrame)
+data4 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_4.csv"), DataFrame)
 m = size(data4,1)
 H4 = zeros(Float64, m)
 error4 = zeros(Float64, m)
@@ -108,7 +108,7 @@ savefig("plots/harmonic_bench_4.pdf")
 ##############################################
 # integer n, real r for generalized H
 H = Symbol("real(H_{n,r})")
-data5 = CSV.read("../data/harmonic_test_data_5.csv", DataFrame)
+data5 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_5.csv"), DataFrame)
 m = size(data5,1)
 H5 = zeros(Float64, m)
 error5 = zeros(Float64, m)

--- a/extended_tests/polylog_bench_a.jl
+++ b/extended_tests/polylog_bench_a.jl
@@ -6,7 +6,7 @@ using BenchmarkTools
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 
 series_1 = Polylogarithms.polylog_series_1
 series_2 = Polylogarithms.polylog_series_2
@@ -17,7 +17,7 @@ L = Symbol("Li_s(z)")
 # input data from Mathematica and reparse into complex numbers
 #for C=1:3
     C = 5
-    filename = @sprintf("../data/polylog_test_data_a_%d.csv", C)
+    filename = joinpath(@__DIR__, "..", "data", "polylog_test_data_a_$(C).csv")
     data1 = CSV.read(filename; delim=",", type=String)
     #    has trouble reading in numbers like "2." so read all into strings, and parse
     data1[!,:s] = parse.(Complex{Float64}, data1[!,:s] )
@@ -75,7 +75,7 @@ L = Symbol("Li_s(z)")
     println("   max abs. error1 = $(maximum( abs.(error1) ))")
     println("   max abs. error2 = $(maximum( abs.(error2) ))")
     
-    fig = figure(@sprintf("../data/polylog_bench_a_%02d.csv", C), figsize=(10,8))
+    fig = figure(joinpath(@__DIR__, "..", "data", "polylog_bench_a_$(C).csv"), figsize=(10,8))
     clf()
     title( @sprintf("s = %f + %f i", real(su), imag(su)) )
     d = 0.01

--- a/extended_tests/polylog_bench_b.jl
+++ b/extended_tests/polylog_bench_b.jl
@@ -6,7 +6,7 @@ using BenchmarkTools
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 
 series_1 = Polylogarithms.polylog_series_1
 series_2 = Polylogarithms.polylog_series_2
@@ -34,7 +34,7 @@ function parse(::Type{Complex{T}}, s::AbstractString) where {T<:Real}
 end
 
 # input data from Mathematica and reparse into complex numbers
-data1 = CSV.read("../data/polylog_test_data_b_1.csv"; delim=",", type=String)
+data1 = CSV.read(joinpath(@__DIR__, "..", "data", "polylog_test_data_b_1.csv"); delim=",", type=String)
 #    has trouble reading in numbers like "2." so read all into strings, and parse
 data1[!,:n] = Int.(parse.(Float64, data1[!,:n] ))
 data1[!,:s] = parse.(Complex{Float64}, data1[!,:s] )

--- a/extended_tests/polylog_bench_c.jl
+++ b/extended_tests/polylog_bench_c.jl
@@ -4,7 +4,7 @@ using BenchmarkTools
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 
 series_1 = Polylogarithms.polylog_series_1
 series_2 = Polylogarithms.polylog_series_2
@@ -17,7 +17,7 @@ L = Symbol("Li_s(z)")
 for C=1:6
     # C = 1
     println("C = $C")
-    filename = @sprintf("../data/polylog_test_data_c_%d.csv", C)
+    filename = joinpath(@__DIR__, "..", "data", "polylog_test_data_c_$(C).csv")
     data1 = CSV.read(filename; delim=",", type=String)
     #    has trouble reading in numbers like "2." so read all into strings, and parse
     data1[!,:s] = parse.(Complex{Float64}, data1[!,:s] )
@@ -80,7 +80,7 @@ for C=1:6
     println("   max abs. error1 = $(maximum( abs.(error1) ))")
     println("   max abs. error2 = $(maximum( abs.(error2) ))")
     
-    fig = figure(@sprintf("../data/polylog_bench_a_%02d.csv", C), figsize=(10,8))
+    fig = figure(joinpath(@__DIR__, "..", "data", "polylog_bench_a_$(C).csv"), figsize=(10,8))
     clf()
     title( @sprintf("s = %f + %f i", real(su), imag(su)) )
     d = 0.01

--- a/extended_tests/polylog_bench_d.jl
+++ b/extended_tests/polylog_bench_d.jl
@@ -7,7 +7,7 @@ using BenchmarkTools
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 
 series_1 = Polylogarithms.polylog_series_1
 series_2 = Polylogarithms.polylog_series_2
@@ -19,7 +19,7 @@ L = Symbol("Li_s(z)")
 # input data from Mathematica and reparse into complex numbers
 #for C=1:3
     C = 1
-    filename = @sprintf("../data/polylog_test_data_d_%d.csv", C)
+    filename = joinpath(@__DIR__, "..", "data", "polylog_test_data_d_$(C).csv")
     data1 = CSV.read(filename; delim=",", type=String)
     #    has trouble reading in numbers like "2." so read all into strings, and parse
     data1[!,:s] = parse.(Complex{Float64}, data1[!,:s] )
@@ -78,7 +78,7 @@ L = Symbol("Li_s(z)")
     println("   max abs. error1 = $(maximum( abs.(error1) ))")
     println("   max abs. error2 = $(maximum( abs.(error2) ))")
     
-    fig = figure(@sprintf("../data/polylog_bench_a_%02d.csv", C), figsize=(10,8))
+    fig = figure(joinpath(@__DIR__, "..", "data", "polylog_bench_a_$(C).csv"), figsize=(10,8))
     clf()
     title( @sprintf("s = %f + %f i", real(su), imag(su)) )
     d = 0.01

--- a/extended_tests/polylog_bench_rand.jl
+++ b/extended_tests/polylog_bench_rand.jl
@@ -15,7 +15,7 @@ L = Symbol("Li_s(z)")
 
 # input data from Mathematica and reparse into complex numbers
 C = 2
-filename = @sprintf("../data/polylog_test_data_rand_%d.csv", C)
+filename = joinpath(@__DIR__, "..", "data", "polylog_test_data_rand_$(C).csv")
 data1 = CSV.read(filename; delim=",", type=String)
 
 # has trouble reading in numbers like "2." so read all into strings, and parse
@@ -70,7 +70,7 @@ error1 = abs.( S1 - Li  )
 rel_error1 = error1 ./ abs.( Li )
 println("   max abs. rel. error1 = $(maximum( abs.(rel_error1) ))")
 
-fig = figure(@sprintf("../data/polylog_bench_rand_1.csv"), figsize=(6,4))
+fig = figure(joinpath(@__DIR__, "..", "data", "polylog_bench_rand_1.csv"), figsize=(6,4))
 clf()
 h = hist(log10.(rel_error1), collect(-16 : 0.5 : -8); align="mid" )
 ylabel("number")

--- a/extended_tests/sequence_test.jl
+++ b/extended_tests/sequence_test.jl
@@ -4,7 +4,7 @@ using Polylogarithms
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 using SpecialFunctions
 
 # chose a "hard value"

--- a/extended_tests/sequence_test2.jl
+++ b/extended_tests/sequence_test2.jl
@@ -4,7 +4,7 @@ using Polylogarithms
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 using SpecialFunctions
 
 # chose a "hard value"

--- a/extended_tests/sequence_test3.jl
+++ b/extended_tests/sequence_test3.jl
@@ -4,7 +4,7 @@ using Polylogarithms
 using DataFrames, CSV
 using PyPlot
 using Printf
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 using SpecialFunctions
 using Base.MathConstants
 twoπ = 2.0*π

--- a/extended_tests/test_zeta.jl
+++ b/extended_tests/test_zeta.jl
@@ -2,9 +2,9 @@ using DataFrames, CSV
 using PyPlot
 using Printf
 using SpecialFunctions
-include("utilities.jl")
+include(joinpath(@__DIR__, "..", "src", "utilities.jl"))
 
-filename = @sprintf("../data/zeta_test_data.csv")
+filename = joinpath(@__DIR__, "..", "data", "zeta_test_data.csv")
 data1 = CSV.read(filename; delim=",", type=String)
 
 data1[!,:s] = parse.(Complex{Float64}, data1[!,:s] )

--- a/test/bernoulli_test.jl
+++ b/test/bernoulli_test.jl
@@ -25,7 +25,7 @@ include("test_defs.jl")
 
     @testset "    dataset 1" begin
         B = Symbol("B_n")
-        data1 = CSV.read("../data/bernoulli_test_data_1.csv", DataFrame)
+        data1 = CSV.read(joinpath(@__DIR__, "..", "data", "bernoulli_test_data_1.csv"), DataFrame)
         m = size(data1,1)
         for i=1:m
             @test bernoulli( data1[i,:n] ) ≅ parse(Rational{Int64},data1[i,B])
@@ -94,7 +94,7 @@ end
  
     @testset " dataset 2" begin 
         B = Symbol("B_n(x)")
-        data2 = CSV.read("../data/bernoulli_test_data_2.csv", DataFrame; delim=",", type=String)
+        data2 = CSV.read(joinpath(@__DIR__, "..", "data", "bernoulli_test_data_2.csv"), DataFrame; delim=",", type=String)
         data2[!,:n] = parse.(Float64, data2[!,:n] )
         data2[!,:x] = parse.(Float64, data2[!,:x] )
         data2[!,B] = parse.(Float64, data2[!,B] )
@@ -106,7 +106,7 @@ end
     
     @testset " dataset 3" begin
         B = Symbol("B_n(x)")
-        data3 = CSV.read("../data/bernoulli_test_data_3.csv", DataFrame; delim=",")
+        data3 = CSV.read(joinpath(@__DIR__, "..", "data", "bernoulli_test_data_3.csv"), DataFrame; delim=",")
         m = size(data3,1)
         for i=1:m
             @test bernoulli( Int(data3[i,:n]),  data3[i,:x]) ≈ data3[i,B]

--- a/test/harmonic_test.jl
+++ b/test/harmonic_test.jl
@@ -37,7 +37,7 @@ include("test_defs.jl")
     end
 
     @testset "    dataset 1 (integer arguments)" begin
-        data1 = CSV.read("../data/harmonic_test_data_1.csv", DataFrame)
+        data1 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_1.csv"), DataFrame)
         m = size(data1,1)
         H = Symbol("real(H_n)")
         for i=1:m
@@ -46,7 +46,7 @@ include("test_defs.jl")
     end
  
     @testset "    dataset 2 (real arguments)" begin
-        data2 = CSV.read("../data/harmonic_test_data_2.csv", DataFrame)
+        data2 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_2.csv"), DataFrame)
         m = size(data2,1)
         H = Symbol("real(H_n)")
         for i=1:m
@@ -55,7 +55,7 @@ include("test_defs.jl")
     end
 
     @testset "    dataset 3 (complex arguments)" begin
-        data3 = CSV.read("../data/harmonic_test_data_3.csv", DataFrame)
+        data3 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_3.csv"), DataFrame)
         m = size(data3,1)
         zr = Symbol("Re(z)")
         zi = Symbol("Im(z)")
@@ -96,7 +96,7 @@ end
 
     @testset "    dataset 4 (integer arguments)" begin
         H = Symbol("real(H_{n,r})")
-        data4 = CSV.read("../data/harmonic_test_data_4.csv", DataFrame)
+        data4 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_4.csv"), DataFrame)
         m = size(data4,1)
         for i=1:m
             @test harmonic( data4[i,:n], data4[i,:r] ) ≅ data4[i,H]
@@ -105,7 +105,7 @@ end
 
     @testset "    dataset 5 (integer n, real r)" begin
         H = Symbol("real(H_{n,r})")
-        data5 = CSV.read("../data/harmonic_test_data_5.csv", DataFrame)
+        data5 = CSV.read(joinpath(@__DIR__, "..", "data", "harmonic_test_data_5.csv"), DataFrame)
         m = size(data5,1)
         for i=1:m
             @test harmonic( data5[i,:n], data5[i,:r] )  ≅ data5[i,H]

--- a/test/polylog_test2.jl
+++ b/test/polylog_test2.jl
@@ -13,7 +13,7 @@ using Printf
 L = Symbol("Li_s(z)")
 @testset "Polylogarithm polylog on data" begin
     for C=1:3
-        filename = @sprintf("../data/polylog_test_data_rand_%d.csv", C)
+        filename = joinpath(@__DIR__, "..", "data", "polylog_test_data_rand_$(C).csv")
         data1 = CSV.read(filename, DataFrame; delim=",", type=String)
 
         # has trouble reading in numbers like "2." so read all into strings, and parse


### PR DESCRIPTION
This allows running `runtests.jl` from any directory, for example as
~~~.jl
julia --project test/runtests.jl
~~~
Using `joinpath` is also more generic regarding the directory separators on different operating systems.