### PR TITLE
Allow for SpecialFunctions v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-SpecialFunctions = "0.10, 1"
+SpecialFunctions = "0.10, 1, 2"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Restricting to v1 can lead to package version clashes with packages requiring at least v2.

Tests on my laptop worked.
