### PR TITLE
Update dependencies and allow precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,6 @@ version = "0.1.1"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
-[compat]
-SpecialFunctions = "0.10, 1"
-julia = "1.3"
-
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/Polylogarithms.jl
+++ b/src/Polylogarithms.jl
@@ -19,7 +19,7 @@ export parse
 ComplexOrReal{T} = Union{T,Complex{T}}
 
 # Some extra parsing routines for reading Mathematics output, but also, complex numbers
-include("utilities.jl")
+#include("utilities.jl")
 
 # Constants
 include("constants.jl")


### PR DESCRIPTION
Since SpecialFunctions.jl is now in version 2.5, I opted to remove the dependency semver requirement. Tests still pass with the newer version. The julia compat was 1.3. I suppose it is better etiquette to just add semver 2 of SpecialFunctions, but then the package will break again (perhaps needlessly, as in this case) in a couple of years.

Also, I noticed that the `parse` redefinitions were preventing precompillation. Since the function is not used in the main package, I removed the inclusion of `utilities.jl`. This functionality should be in the test files (which also need more work). This change solves #13, but some tests that compare with the Mathematica output may fail.